### PR TITLE
Update rename_merge_pdf_fields.py

### DIFF
--- a/rename_merge_pdf_fields.py
+++ b/rename_merge_pdf_fields.py
@@ -16,8 +16,19 @@ from PyPDF2 import PdfReader, PdfWriter
 from PyPDF2.generic import NameObject, TextStringObject, DictionaryObject, BooleanObject
 
 def natural_key(s: str):
-    # Sort like a human: split digits and text so "...9" comes before "...10"
-    return [int(t) if t.isdigit() else t.lower() for t in re.findall(r'\d+|\D+', s)]
+    """
+    Return a key that compares safely by tagging each token with its type:
+    (0, int_value) for digits, (1, lower_string) for text.
+    This avoids int<->str comparisons during sorting.
+    """
+    parts = re.findall(r'\d+|\D+', s)
+    key = []
+    for t in parts:
+        if t.isdigit():
+            key.append((0, int(t)))
+        else:
+            key.append((1, t.lower()))
+    return tuple(key)
 
 def rename_fields_on_page(page, prefix: str) -> int:
     """Rename all /T names on a page's widget annotations using a prefix."""


### PR DESCRIPTION
_**Description:**_

Updated natural_key() function to ensure consistent type-safe sorting when processing PDF filenames.

Previously, mixed integer and string comparisons in the sort key caused a TypeError: '<' not supported between instances of 'int' and 'str'.

New implementation tags each part of the filename as numeric or text, preventing comparison conflicts.

Preserves all original functionality and logic while ensuring stable, human-friendly ordering of files (e.g., ...9.pdf comes before ...10.pdf).

_**Impact:**_

Eliminates crashes during processing of student folders with numbered PDFs.

Ensures predictable merge order for multi-page forms.

_**Tested:**_

Verified on datasets containing mixed numeric/text filenames.

Confirmed output matches expected field renaming and merging behavior.